### PR TITLE
Commented loadMigrationsFrom

### DIFF
--- a/src/ChatSystemServiceProvider.php
+++ b/src/ChatSystemServiceProvider.php
@@ -13,7 +13,7 @@ class ChatSystemServiceProvider extends ServiceProvider {
   public function boot(): void {
     // $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'myckhel');
     // $this->loadViewsFrom(__DIR__.'/../resources/views', 'myckhel');
-    $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+    // $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     $this->loadRoutesFrom(__DIR__.'/routes/api.php');
 
     // Publishing is only necessary when using the CLI.


### PR DESCRIPTION
Hallo @myckhel I tested it in a brand new laravel project and it worked fine.

1. When running php artisan migrate without publishing it only creates the base tables (users, password resets, and failed jobs).
2. After running `php artisan vendor:publish --provider="Myckhel\ChatSystem\ChatSystemServiceProvider" --tag='migrations'` , it copies all the migrations in the folder with the same name.
3. Running again the same command it doesn't duplicate the migrations.
4. Running `php artisan migrate` again, it creates the tables corresponding to the package.

I hope this works, i think it was easy, I've just commented the `$this->loadMigrationsFrom(__DIR__.'/../database/migrations');` line in the boot function from the ChatSystemServiceProvider.php. It think it fixes #10 

By the way i've learned a lot. Thanks for letting me contribute.
Hernán.